### PR TITLE
Update README.md

### DIFF
--- a/circuit-breaker-slm-clustered/README.md
+++ b/circuit-breaker-slm-clustered/README.md
@@ -18,6 +18,7 @@ x-ibm-configuration:
   assembly:
     execute:
       - circuit-breaker-slm-clustered:
+          version: 1.0.0      
           key: default
           concurrency: 1
       - invoke:

--- a/circuit-breaker-slm-clustered/README.md
+++ b/circuit-breaker-slm-clustered/README.md
@@ -1,6 +1,8 @@
 # Circuit Breaker SLM with Peering/Clustered
 
-The Circuit Breaker SLM policy can be used in IBM API Connect to reject new connections when the total request concurrency exceeds a configurable threshold. Supports count partitioning using a unique string identifier (key). This policy is also clustered or peered using SLM Peering allowing the count to be distributed across a cluster of API Gateways.
+The Circuit Breaker SLM policy can be used in IBM API Connect to reject new connections when the total request concurrency exceeds a configurable threshold.
+Supports count partitioning using a unique string identifier (key). This policy is also clustered or peered using SLM Peering allowing the count to be 
+distributed across a cluster of API Gateways.
 
 ## Prerequisites
 


### PR DESCRIPTION
If I did not have the version line it only got a simple 500 (DataPower not aware of the policy yet - only the catalog import was done).  
Adding the version line got me a better error:
  "httpCode": "500",
  "httpMessage": "Internal Server Error",
  "moreInformation": "Error opening URL 'local:///policy/e615ca5a40cf270e49d5c10f3/circuit-breaker-slm-clustered_v1.0.0/check.xsl'"